### PR TITLE
Use https instead of http in urls

### DIFF
--- a/examples/echo/pom.xml
+++ b/examples/echo/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.twitter</groupId>
   <artifactId>iago2-echo</artifactId>
@@ -17,19 +17,19 @@
     <repository>
       <id>twitter</id>
       <name>Twitter Public Repo</name>
-      <url>http://maven.twttr.com</url>
+      <url>https://maven.twttr.com</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>twitter</id>
       <name>Twitter Public Repo</name>
-      <url>http://maven.twttr.com</url>
+      <url>https://maven.twttr.com</url>
     </pluginRepository>
     <pluginRepository>
       <id>repo1</id>
       <name>Maven Central</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/examples/echo/src/assembly/package-dist.xml
+++ b/examples/echo/src/assembly/package-dist.xml
@@ -1,6 +1,6 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly xmlns="https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>package-dist</id>
   <formats>
     <format>jar</format>

--- a/examples/web/pom.xml
+++ b/examples/web/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.twitter</groupId>
   <artifactId>iago2-web</artifactId>
@@ -17,19 +17,19 @@
     <repository>
       <id>twitter</id>
       <name>Twitter Public Repo</name>
-      <url>http://maven.twttr.com</url>
+      <url>https://maven.twttr.com</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>twitter</id>
       <name>Twitter Public Repo</name>
-      <url>http://maven.twttr.com</url>
+      <url>https://maven.twttr.com</url>
     </pluginRepository>
     <pluginRepository>
       <id>repo1</id>
       <name>Maven Central</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/examples/web/src/assembly/package-dist.xml
+++ b/examples/web/src/assembly/package-dist.xml
@@ -1,6 +1,6 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly xmlns="https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>package-dist</id>
   <formats>
     <format>jar</format>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.twitter</groupId>
   <artifactId>iago2</artifactId>
@@ -29,14 +29,14 @@
       <id>artifactory-release</id>
       <name>Twitter Artifactory Releases</name>
       <url>
-        http://artifactory.local.twitter.com/libs-releases-local
+        https://artifactory.local.twitter.com/libs-releases-local
       </url>
     </repository>
     <snapshotRepository>
       <id>artifactory-snapshot</id>
       <name>Twitter Artifactory Snapshots</name>
       <url>
-        http://artifactory.local.twitter.com/libs-snapshots-local
+        https://artifactory.local.twitter.com/libs-snapshots-local
       </url>
     </snapshotRepository>
   </distributionManagement>
@@ -44,14 +44,14 @@
     <repository>
       <id>twitter</id>
       <name>Twitter Public Repo</name>
-      <url>http://maven.twttr.com</url>
+      <url>https://maven.twttr.com</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo1</id>
       <name>Maven Central</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/src/assembly/package-dist.xml
+++ b/src/assembly/package-dist.xml
@@ -1,6 +1,6 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly xmlns="https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 https://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>package-dist</id>
   <formats>
     <format>zip</format>


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.